### PR TITLE
peer2peer: fix build after changes in TAPI

### DIFF
--- a/vswitch-ts/peer2peer/p2p_prologue.c
+++ b/vswitch-ts/peer2peer/p2p_prologue.c
@@ -181,7 +181,7 @@ main(int argc, char **argv)
     CHECK_RC(te_kvpair_add(&expand_vars, "IF_IUT_PCI", "%s",
                            iut_if_pci_info.pci_addr));
     CHECK_RC(te_kvpair_add(&expand_vars, "IF_IUT_DRIVER", "%s",
-                           iut_if_pci_info.ta_driver));
+                           iut_if_pci_info.net_driver));
     CHECK_RC(te_kvpair_add(&expand_vars, "TA_TST", "%s", tst_host->ta));
     CHECK_RC(te_kvpair_add(&expand_vars, "IF_TST", "%s", tst_if->if_name));
     CHECK_RC(te_kvpair_add(&expand_vars, "VLAN_ID", "%u", 5));


### PR DESCRIPTION
The following changeset in Test Envifonment
d3b144ca6baa ("lib/tapi: include fuller driver info in PCI node description") changes name of the variable used for network driver.